### PR TITLE
Configurable options to set Source and limit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/takahiromiyamoto/go-xeger
+
+go 1.17

--- a/xeger.go
+++ b/xeger.go
@@ -18,24 +18,75 @@ const (
 	printableNotNL  = digits + ascii_letters + punctuation + control
 )
 
-var src = rand.NewSource(time.Now().UnixNano())
+func defaultSource() Source { return rand.NewSource(time.Now().UnixNano()) }
 
-const limit = 10
+const defaultLimit = 10
 
-type Xeger struct {
-	re *syntax.Regexp
+// A Source represents a source of uniformly-distributed pseudo-random int64
+// values in the range [0, 1<<63).  This is a subset of interface rand.Source
+// to specify only the methods required by Xeger.
+type Source interface {
+	Int63() int64
 }
 
-func NewXeger(regex string) (*Xeger, error) {
+type Xeger struct {
+	re     *syntax.Regexp
+	source Source
+	limit  int
+}
+
+func NewXeger(regex string, opts ...Option) (*Xeger, error) {
 	re, err := syntax.Parse(regex, syntax.Perl)
 	if err != nil {
 		return nil, err
 	}
+	x := &Xeger{re: re}
 
-	x := &Xeger{re}
+	for _, o := range opts {
+		o.apply(x)
+	}
+
+	// Set defaults
+	if x.source == nil {
+		x.source = defaultSource()
+	}
+	if x.limit <= 0 {
+		x.limit = defaultLimit
+	}
+
 	return x, nil
 }
 
+// Option configures Xeger using the functional options paradigm.
+type Option interface {
+	apply(x *Xeger)
+}
+
+type optionFunc func(x *Xeger)
+
+func (f optionFunc) apply(x *Xeger) {
+	f(x)
+}
+
+// WithSource returns an Option that configures a Xeger with the given Source
+// of random numbers.
+func WithSource(s Source) Option {
+	return optionFunc(func(x *Xeger) {
+		x.source = s
+	})
+}
+
+// WithLimit returns an Option that configures a Zeger with the given limit for
+// the number of repeated subexpressions to generate (i.e., for "*" and "+"
+// operators in a regular expression).
+func WithLimit(limit int) Option {
+	return optionFunc(func(x *Xeger) {
+		x.limit = limit
+	})
+}
+
+// Generate returns a string that matches the regular expression with which
+// Xeger was created.
 func (x *Xeger) Generate() string {
 	return x.generateFromRegexp(x.re)
 }
@@ -52,7 +103,7 @@ func (x *Xeger) generateFromRegexp(re *syntax.Regexp) string {
 			sum += 1 + int(re.Rune[i+1]-re.Rune[i])
 		}
 
-		index := rune(randInt(sum))
+		index := rune(x.randInt(sum))
 		for i := 0; i < len(re.Rune); i += 2 {
 			delta := re.Rune[i+1] - re.Rune[i]
 			if index <= delta {
@@ -63,38 +114,38 @@ func (x *Xeger) generateFromRegexp(re *syntax.Regexp) string {
 		return ""
 
 	case syntax.OpAnyCharNotNL: // matches any character except newline
-		c := printableNotNL[randInt(len(printableNotNL))]
+		c := printableNotNL[x.randInt(len(printableNotNL))]
 		return string([]byte{c})
 
 	case syntax.OpAnyChar: // matches any character
-		c := printable[randInt(len(printable))]
+		c := printable[x.randInt(len(printable))]
 		return string([]byte{c})
 
 	case syntax.OpCapture: // capturing subexpression with index Cap, optional name Name
 		return x.generateFromSubexpression(re, 1)
 
 	case syntax.OpStar: // matches Sub[0] zero or more times
-		return x.generateFromSubexpression(re, randInt(limit+1))
+		return x.generateFromSubexpression(re, x.randInt(x.limit+1))
 
 	case syntax.OpPlus: // matches Sub[0] one or more times
-		return x.generateFromSubexpression(re, randInt(limit)+1)
+		return x.generateFromSubexpression(re, x.randInt(x.limit)+1)
 
 	case syntax.OpQuest: // matches Sub[0] zero or one times
-		return x.generateFromSubexpression(re, randInt(2))
+		return x.generateFromSubexpression(re, x.randInt(2))
 
 	case syntax.OpRepeat: // matches Sub[0] at least Min times, at most Max (Max == -1 is no limit)
 		max := re.Max
 		if max == -1 {
-			max = limit
+			max = x.limit
 		}
-		count := randInt(max-re.Min+1) + re.Min
+		count := x.randInt(max-re.Min+1) + re.Min
 		return x.generateFromSubexpression(re, count)
 
 	case syntax.OpConcat: // matches concatenation of Subs
 		return x.generateFromSubexpression(re, 1)
 
 	case syntax.OpAlternate: // matches alternation of Subs
-		i := randInt(len(re.Sub))
+		i := x.randInt(len(re.Sub))
 		return x.generateFromRegexp(re.Sub[i])
 
 		/*
@@ -129,6 +180,6 @@ func (x *Xeger) generateFromSubexpression(re *syntax.Regexp, count int) string {
 // n must be > 0, but int31n does not check this; the caller must ensure it.
 // randInt is simpler and faster than rand.Intn(n), because xeger just
 // generates strings at random.
-func randInt(n int) int {
-	return int(src.Int63() % int64(n))
+func (x *Xeger) randInt(n int) int {
+	return int(x.source.Int63() % int64(n))
 }


### PR DESCRIPTION
It can be useful to be able to control the configuration of a `Xeger` instance.  Add two configurable options that may be passed to the `NewXeger()` constructor:
* `WithSource()` sets the source of random numbers.
* `WithLimit()` sets the number of repeated subexpressions (i.e., "*" and "+" operators).